### PR TITLE
Update cloudformation path

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 data "local_file" "cloudformation_template" {
-  filename = "${path.module}/cloudformation.yml"
+  filename = "${path.module}/cloudformation-chatbot.yml"
 }
 
 resource "aws_cloudformation_stack" "chatbot_slack_configuration" {


### PR DESCRIPTION
When `terraform init` is run, the module is installed as-is, which uses the `cloudformation-chatbot.yml` filename.
```
$ ll .terraform/modules/chatbot/                        
total 24K
-rw-rw-r-- 1 pratt pratt 1.1K Dec 16 16:38 LICENSE
-rw-rw-r-- 1 pratt pratt 2.3K Dec 16 16:38 README.md
-rw-rw-r-- 1 pratt pratt 2.0K Dec 16 16:38 cloudformation-chatbot.yml
-rw-rw-r-- 1 pratt pratt 1.7K Dec 16 16:38 input.tf
-rw-rw-r-- 1 pratt pratt  637 Dec 16 16:38 main.tf
-rw-rw-r-- 1 pratt pratt   44 Dec 16 16:38 versions.tf
```